### PR TITLE
CoffeeScript output isn't wrapped in an anonymous function anymore

### DIFF
--- a/test/template_handler_test.rb
+++ b/test/template_handler_test.rb
@@ -21,6 +21,6 @@ class TemplateHandlerTest < ActiveSupport::TestCase
   test "coffee views are served as javascript" do
     get "/site/index.js"
 
-    assert_match "(function() {\n  alert('hello world');\n}).call(this);\n", last_response.body
+    assert_match "alert('hello world');\n", last_response.body
   end
 end


### PR DESCRIPTION
Starting with coffee-script-source 1.1.3 the output of coffeescript output isn't wrapped in anonymous functions.

This fixes the broken template handler test
