### PR TITLE
Added homepage in gemspec

### DIFF
--- a/coffee-rails.gemspec
+++ b/coffee-rails.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Santiago Pastorino"]
   s.email       = ["santiago@wyeworks.com"]
-  s.homepage    = ""
+  s.homepage    = "https://github.com/rails/coffee-rails"
   s.summary     = %q{Coffee Script adapter for the Rails asset pipeline.}
   s.description = %q{Coffee Script adapter for the Rails asset pipeline.}
 


### PR DESCRIPTION
Homepage url in gemspec was empty. I set it to:
https://github.com/rails/coffee-rails

This is required for gem2rpm to work correctly.
