### PR TITLE
"CoffeeScript", not "Coffee Script", in README and gemspec.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # Coffee-Rails
 
-Coffee Script adapter for the Rails asset pipeline. Also adds support to use CoffeeScript to respond to JavaScript requests (use .js.coffee views).
+CoffeeScript adapter for the Rails asset pipeline. Also adds support to use CoffeeScript to respond to JavaScript requests (use .js.coffee views).
 
 ## Installation
 

--- a/coffee-rails.gemspec
+++ b/coffee-rails.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.authors     = ["Santiago Pastorino"]
   s.email       = ["santiago@wyeworks.com"]
   s.homepage    = "https://github.com/rails/coffee-rails"
-  s.summary     = %q{Coffee Script adapter for the Rails asset pipeline.}
-  s.description = %q{Coffee Script adapter for the Rails asset pipeline.}
+  s.summary     = %q{CoffeeScript adapter for the Rails asset pipeline.}
+  s.description = %q{CoffeeScript adapter for the Rails asset pipeline.}
 
   s.rubyforge_project = "coffee-rails"
 


### PR DESCRIPTION
As per [the official CoffeeScript site](http://coffeescript.org/).
