### PR TITLE
Update URL to the CoffeeScript site

### DIFF
--- a/lib/rails/generators/coffee/assets/templates/javascript.js.coffee
+++ b/lib/rails/generators/coffee/assets/templates/javascript.js.coffee
@@ -1,3 +1,3 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
+# You can use CoffeeScript in this file: http://coffeescript.org/


### PR DESCRIPTION
The official CoffeeScript site is now available at http://coffeescript.org/ ... there's no need to link specifically to the github page.
