### PR TITLE
need to use journey from git

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,7 @@ gemspec
 gem "rails", :git => "git://github.com/rails/rails"
 gem 'activerecord-deprecated_finders', :git => 'git://github.com/rails/activerecord-deprecated_finders'
 
+gem 'journey', github: "rails/journey"
+
 # To use debugger
 # gem 'debugger'


### PR DESCRIPTION
Hi, folks. 
Don't think that this is essential changing, but I was not able to run `bundle install` on `coffee-rails` master. I've got this error message: 
`Could not find gem 'journey (~> 2.0.0) ruby', which is required by gem 'coffee-rails (>= 0) ruby', in any of the sources.`
[Here](https://github.com/carlhuda/bundler/issues/1470) is a description of the same issue. The problem is that "Journey is not available from Rubygems.org, so you'll need to add it to your Gemfile by hand until the Rails team sees fit to release it". To cope with it I have added `journey` gem to Gemfile like @jonleighton have made it [in this commit](https://github.com/rails/activerecord-deprecated_finders/commit/be9f1b4511f3f9a468672199bc2f7e5cbb4f59ca).
