### PR TITLE
add license information to the gemspec

### DIFF
--- a/coffee-rails.gemspec
+++ b/coffee-rails.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.test_files    = ["test/assets_generator_test.rb","test/assets_test.rb","test/controller_generator_test.rb","test/scaffold_generator_test.rb","test/support/routes.rb","test/support/site/index.js.coffee","test/template_handler_test.rb","test/test_helper.rb"]
   s.executables   = []
   s.require_paths = ["lib"]
+  s.license = "MIT"
 end

--- a/coffee-rails.gemspec.erb
+++ b/coffee-rails.gemspec.erb
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.test_files    = [<%= test_files.map(&:inspect).join ',' %>]
   s.executables   = [<%= executables.map(&:inspect).join ',' %>]
   s.require_paths = ["lib"]
+  s.license = "MIT"
 end


### PR DESCRIPTION
this way you get the license when using the rubygems.org API
