### PR TITLE
Fix the build

### DIFF
--- a/test/template_handler_test.rb
+++ b/test/template_handler_test.rb
@@ -1,8 +1,10 @@
 require 'test_helper'
 require 'action_controller'
+require 'action_view'
 require 'coffee-rails'
 
 class SiteController < ActionController::Base
+  include ::ActionView::Rendering if Rails.version > '4.1'
   self.view_paths = File.expand_path("../support", __FILE__)
 end
 


### PR DESCRIPTION
Hello,

Since rails/rails#11396, Action View has been extracted from Action Pack so we need to include `ActionView::Rendering` to the dummy controller.

Have a nice day.
