### PR TITLE
Allow sudo to mitigate the Rubinius failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 cache: bundler
 before_install:


### PR DESCRIPTION
Hello,

Even though forbidding sudo to be used would allow us to run the Travis build on the new container-based infrastructure, this makes the Rubinius build to fail as it looks like RVM needs the sudo command to install
Rubinius.

Cross-refs #64.

Have a nice day.
