### PR TITLE
Fix build failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tmp/
 test/tmp
 Gemfile.lock
+gemfiles/*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2
-  - jruby
+  - 2.2.5
+  - 2.3.1
+  - jruby-9.0.5.0
   - rbx-2
 gemfile:
   - Gemfile
@@ -19,7 +20,7 @@ matrix:
     - gemfile: Gemfile
   include:
     - gemfile: Gemfile
-      rvm: 2.2
+      rvm: 2.2.5
 notifications:
   email: false
   campfire:

--- a/gemfiles/Gemfile-4-0-stable
+++ b/gemfiles/Gemfile-4-0-stable
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', github: 'rails/rails', branch: '4-0-stable'
+gem "mime-types", "< 3"

--- a/gemfiles/Gemfile-4-1-stable
+++ b/gemfiles/Gemfile-4-1-stable
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', github: 'rails/rails', branch: '4-1-stable'
+gem "mime-types", "< 3"

--- a/gemfiles/Gemfile-4-2-stable
+++ b/gemfiles/Gemfile-4-2-stable
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', github: 'rails/rails', branch: '4-2-stable'
+gem "mime-types", "< 3"


### PR DESCRIPTION
- This prevents installing mime-types-data (3.2016.0221) which fails on
  1.9.3 as it requires Ruby 2.

r? @rafaelfranca 