### PR TITLE
Loosened railties dependency as need by Rails 5.2.0.alpha - Fixed #88

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2.5
-  - 2.3.1
+  - 2.3.3
+  - 2.4.0
   - jruby-9.0.5.0
   - rbx-2
 gemfile:
@@ -25,11 +26,15 @@ matrix:
     - gemfile: Gemfile
       rvm: 2.2.5
     - gemfile: Gemfile
-      rvm: 2.3.1
+      rvm: 2.3.3
+    - gemfile: Gemfile
+      rvm: 2.4.0
     - gemfile: gemfiles/Gemfile-5-0-stable
       rvm: 2.2.5
     - gemfile: gemfiles/Gemfile-5-0-stable
-      rvm: 2.3.1
+      rvm: 2.3.3
+    - gemfile: gemfiles/Gemfile-5-0-stable
+      rvm: 2.4.0
 notifications:
   email: false
   campfire:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 cache: bundler
+sudo: false
 before_install:
   - gem install bundler
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in coffee-rails.gemspec
 gemspec
 
-gem "rails", github: "rails/rails"
+gem 'rails', git: 'https://github.com/rails/rails'

--- a/coffee-rails.gemspec
+++ b/coffee-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "coffee-rails"
 
   s.add_runtime_dependency 'coffee-script', '>= 2.2.0'
-  s.add_runtime_dependency 'railties',      '>= 4.0.0', '< 5.2.x'
+  s.add_runtime_dependency 'railties',      '>= 4.0.0', '< 6.0.x'
 
   s.files         = ["CHANGELOG.md","MIT-LICENSE","README.md","lib/assets/javascripts/coffee-script.js.erb","lib/coffee-rails.rb","lib/coffee/rails/engine.rb","lib/coffee/rails/js_hook.rb","lib/coffee/rails/template_handler.rb","lib/coffee/rails/version.rb","lib/rails/generators/coffee/assets/assets_generator.rb","lib/rails/generators/coffee/assets/templates/javascript.coffee"]
   s.executables   = []

--- a/coffee-rails.gemspec.erb
+++ b/coffee-rails.gemspec.erb
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "coffee-rails"
 
   s.add_runtime_dependency 'coffee-script', '>= 2.2.0'
-  s.add_runtime_dependency 'railties',      '>= 4.0.0', '< 5.2.x'
+  s.add_runtime_dependency 'railties',      '>= 4.0.0', '< 6.0.x'
 
   s.files         = [<%= files.map(&:inspect).join ',' %>]
   s.executables   = [<%= executables.map(&:inspect).join ',' %>]


### PR DESCRIPTION
 * Loosened railties dependency in the 2 gemspec files. Fixed #88 .
 * Add "sudo: false" to .travis.yml as requested by TravisCI.
 * Enhanced security by changed "github:" to "git: https" in Gemfile file.