### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 cache: bundler
+# To use rbx environment.
+dist: trusty
 sudo: false
 before_install:
   - gem install bundler
@@ -7,11 +9,12 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2.5
-  - 2.3.3
-  - 2.4.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
   - jruby-9.0.5.0
-  - rbx-2
+  - rbx-3
 gemfile:
   - Gemfile
   - gemfiles/Gemfile-4-0-stable
@@ -21,20 +24,44 @@ gemfile:
 matrix:
   exclude:
     - gemfile: Gemfile
+    - gemfile: gemfiles/Gemfile-4-0-stable
+      rvm: 2.4.1
+    - gemfile: gemfiles/Gemfile-4-1-stable
+      rvm: 2.4.1
+    - gemfile: gemfiles/Gemfile-4-0-stable
+      rvm: ruby-head
+    - gemfile: gemfiles/Gemfile-4-1-stable
+      rvm: ruby-head
+    - gemfile: gemfiles/Gemfile-4-0-stable
+      rvm: rbx-3
+    - gemfile: gemfiles/Gemfile-4-1-stable
+      rvm: rbx-3
     - gemfile: gemfiles/Gemfile-5-0-stable
   include:
     - gemfile: Gemfile
-      rvm: 2.2.5
+      rvm: 2.2.7
     - gemfile: Gemfile
-      rvm: 2.3.3
+      rvm: 2.3.4
     - gemfile: Gemfile
-      rvm: 2.4.0
+      rvm: 2.4.1
+    - gemfile: Gemfile
+      rvm: ruby-head
+    - gemfile: Gemfile
+      rvm: rbx-3
     - gemfile: gemfiles/Gemfile-5-0-stable
-      rvm: 2.2.5
+      rvm: 2.2.7
     - gemfile: gemfiles/Gemfile-5-0-stable
-      rvm: 2.3.3
+      rvm: 2.3.4
     - gemfile: gemfiles/Gemfile-5-0-stable
-      rvm: 2.4.0
+      rvm: 2.4.1
+    - gemfile: gemfiles/Gemfile-5-0-stable
+      rvm: ruby-head
+    - gemfile: gemfiles/Gemfile-5-0-stable
+      rvm: rbx-3
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: rbx-3
+  fast_finish: true
 notifications:
   email: false
   campfire:


### PR DESCRIPTION
I updated Rubies to latest version.
I also added ruby-head to Travis as allow_failures.

I think this is useful. Because we can prepare before next version Ruby 2.5 release.
We can see this kind of logic in `rails/rails`, `rspec` and `cucumber` and etc too.
  
https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to merge?

Thanks.