### PR TITLE
Register ERBTracker as DependencyTracker for .coffee files to support…

### DIFF
--- a/lib/coffee/rails/template_handler.rb
+++ b/lib/coffee/rails/template_handler.rb
@@ -15,4 +15,6 @@ end
 
 ActiveSupport.on_load(:action_view) do
   ActionView::Template.register_template_handler :coffee, Coffee::Rails::TemplateHandler
+  # Register ERB DependencyTracker for .coffee files to enable digesting.
+  ActionView::DependencyTracker.register_tracker :coffee, ActionView::DependencyTracker::ERBTracker
 end


### PR DESCRIPTION
While researching [rails#28503](https://github.com/rails/rails/issues/28503) I noticed that `.coffee` files do not resolve dependencies because they have not had a dependency tracker registered.

Given `objects/show.coffee`:

    resourceHtml = ('<%= j render partial: 'resource', locals: {resource: resource} %>')

Running `rake cache_digest:nested_dependencies TEMPLATE=objects/show` would return an empty array (no dependencies).

However, once `ActionView::DependencyTracker::ERBTracker` has been registered as a tracker for `.coffee` files, running the same rake task properly resolves the dependencies.

I don't know how we can test this particular behaviour within this gem given that ActionView isn't available here, but if there's way to do so I'd love to include a few.