### PR TITLE
Resubmitting Dependency Tracker Issue

### DIFF
--- a/lib/coffee/rails/template_handler.rb
+++ b/lib/coffee/rails/template_handler.rb
@@ -15,6 +15,8 @@ end
 
 ActiveSupport.on_load(:action_view) do
   ActionView::Template.register_template_handler :coffee, Coffee::Rails::TemplateHandler
+  # Loads DependencyTracker
+  require 'action_view/dependency_tracker'
   # Register ERB DependencyTracker for .coffee files to enable digesting.
   ActionView::DependencyTracker.register_tracker :coffee, ActionView::DependencyTracker::ERBTracker
 end


### PR DESCRIPTION
Re: issue #91, this corrects the `NameError` generated during testing.