### PR TITLE
Run tests against Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ cache: bundler
 # To use rbx environment.
 dist: trusty
 sudo: false
-before_install:
-  - gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0
@@ -13,6 +11,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - ruby-head
   - jruby-9.0.5.0
   - rbx-3
@@ -34,6 +33,10 @@ matrix:
     - gemfile: gemfiles/Gemfile-4-1-stable
       rvm: 2.5
     - gemfile: gemfiles/Gemfile-4-0-stable
+      rvm: 2.6
+    - gemfile: gemfiles/Gemfile-4-1-stable
+      rvm: 2.6
+    - gemfile: gemfiles/Gemfile-4-0-stable
       rvm: ruby-head
     - gemfile: gemfiles/Gemfile-4-1-stable
       rvm: ruby-head
@@ -45,8 +48,6 @@ matrix:
       rvm: rbx-3
     - gemfile: gemfiles/Gemfile-5-0-stable
   include:
-    - gemfile: Gemfile
-      rvm: 2.4
     - gemfile: Gemfile
       rvm: 2.5
     - gemfile: Gemfile
@@ -61,6 +62,8 @@ matrix:
       rvm: 2.4
     - gemfile: gemfiles/Gemfile-5-0-stable
       rvm: 2.5
+    - gemfile: gemfiles/Gemfile-5-0-stable
+      rvm: 2.6
     - gemfile: gemfiles/Gemfile-5-0-stable
       rvm: ruby-head
     - gemfile: gemfiles/Gemfile-5-0-stable


### PR DESCRIPTION
We should run the Rails 5.x tests against Ruby 2.6 as well.