### PR TITLE
Remove explicit Bundler install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ cache: bundler
 # To use rbx environment.
 dist: trusty
 sudo: false
-before_install:
-  - gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Ruby < 2.3 need Bundler < 2 (https://github.com/rails/coffee-rails/issues/103), all newer Rubies can utilize Bundler >= 2.

Travis, as of a month ago, can intelligently choose the Bundler version for us. ([Changelog](https://changelog.travis-ci.com/latest-bundler-1-x-is-installed-for-ruby-2-3-0-86330))