### PR TITLE
Remove Gemfile + Ruby 2.4 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,6 @@ matrix:
     - gemfile: gemfiles/Gemfile-5-0-stable
   include:
     - gemfile: Gemfile
-      rvm: 2.4
-    - gemfile: Gemfile
       rvm: 2.5
     - gemfile: Gemfile
       rvm: ruby-head


### PR DESCRIPTION
[Rails 6.0](https://github.com/rails/rails/releases/tag/v6.0.0.beta1) requires Ruby >= 2.5. Thus we can no longer run [Gemfile + 2.4 in Travis](https://travis-ci.org/rails/coffee-rails/jobs/499625014).

<img width="316" alt="screen shot 2019-02-28 at 13 35 32" src="https://user-images.githubusercontent.com/1557529/53541551-be2b0b00-3b5d-11e9-92d0-f51d45672f0b.png">
