### PR TITLE
Skip CoffeeScript generate tests for Rails >= 6

### DIFF
--- a/test/assets_generator_test.rb
+++ b/test/assets_generator_test.rb
@@ -8,6 +8,8 @@ class AssetGeneratorTest < Rails::Generators::TestCase
   setup :prepare_destination
 
   def test_assets
+    return if Rails::VERSION::MAJOR >= 6
+
     run_generator %w(posts)
     assert_no_file "app/assets/javascripts/posts.js"
     assert_file "app/assets/javascripts/posts.coffee"

--- a/test/controller_generator_test.rb
+++ b/test/controller_generator_test.rb
@@ -12,6 +12,8 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_assets
+    return if Rails::VERSION::MAJOR >= 6
+
     run_generator %w(posts --javascript-engine=coffee --orm=false)
     assert_no_file "app/assets/javascripts/posts.js"
     assert_file "app/assets/javascripts/posts.coffee"

--- a/test/scaffold_generator_test.rb
+++ b/test/scaffold_generator_test.rb
@@ -12,6 +12,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_assets
+    return if Rails::VERSION::MAJOR >= 6
+
     run_generator %w(posts --javascript-engine=coffee --orm=false)
     assert_no_file "app/assets/javascripts/posts.js"
     assert_file "app/assets/javascripts/posts.coffee"


### PR DESCRIPTION
Rails >= 6.0 no longer generates CoffeeScript files, at least by default. This is causing [failures](https://travis-ci.org/rails/coffee-rails/jobs/499625207).
<img width="1440" alt="screen shot 2019-02-28 at 14 04 11" src="https://user-images.githubusercontent.com/1557529/53542524-3398da80-3b62-11e9-94ab-3e36f8d4c516.png">
Rails 5.2.2 left, Rails 6.0.0 beta 2 right

Thus, I've added a Rails version check around the CoffeeScript file generation assertions.