### PR TITLE
Add Ruby 2.6 Gemfile test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ matrix:
     - gemfile: Gemfile
       rvm: 2.5
     - gemfile: Gemfile
+      rvm: 2.6
+    - gemfile: Gemfile
       rvm: ruby-head
     - gemfile: Gemfile
       rvm: rbx-3


### PR DESCRIPTION
Let's run the Gemfile test against Ruby 2.5 and Ruby 2.6.

Related to https://github.com/rails/coffee-rails/pull/102. (add support for Ruby 2.6)