### PR TITLE
Stop testing Ruby <2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ cache: bundler
 dist: trusty
 sudo: false
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
   - 2.2
   - 2.3
   - 2.4


### PR DESCRIPTION
Considering `activesupport-5.2.2.1 requires ruby version >= 2.2.2` and we want to drop support for Rails <5.2, we can stop testing Ruby <2.2.

Related https://github.com/rails/coffee-rails/pull/108