### PR TITLE
Update Travis CI JRuby to 9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
   - 2.5
   - 2.6
   - ruby-head
-  - jruby-9.0.5.0
+  - jruby-9.2.6.0
   - rbx-3
 gemfile:
   - Gemfile


### PR DESCRIPTION
Simply update the version of JRuby used in Travis CI testing to latest, [`9.2.6.0`](https://www.jruby.org/2019/02/11/jruby-9-2-6-0).