### PR TITLE
Call handler with source to fix deprecation

### DIFF
--- a/lib/coffee/rails/template_handler.rb
+++ b/lib/coffee/rails/template_handler.rb
@@ -6,11 +6,8 @@ module Coffee
       end
 
       def self.call(template, source = nil)
-        compiled_source = if source
-          erb_handler.call(template, source)
-        else
-          erb_handler.call(template)
-        end
+        source ||= template.source
+        compiled_source = erb_handler.call(template, source)
         "CoffeeScript.compile(begin;#{compiled_source};end)"
       end
     end


### PR DESCRIPTION
Noticed a deprecation warning: 

```
Change:
  >> Coffee::Rails::TemplateHandler.call(template)
To:
  >> Coffee::Rails::TemplateHandler.call(template, source)
 (called from <top (required)> at /Users/guilhermemansur/Desktop/rails-contributors/config/environment.rb:5)
```

It's deprecated to call template handlers without a source argument. This patch
fixes it so that the previous behaviour is preserved but removes the
deprecation.