### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/coffee-rails.gemspec
+++ b/coffee-rails.gemspec
@@ -11,6 +11,13 @@ Gem::Specification.new do |s|
   s.summary     = %q{CoffeeScript adapter for the Rails asset pipeline.}
   s.description = %q{CoffeeScript adapter for the Rails asset pipeline.}
 
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/rails/coffee-rails/issues",
+    "changelog_uri"     => "https://github.com/rails/coffee-rails/blob/v#{s.version}/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/coffee-rails/#{s.version}",
+    "source_code_uri"   => "https://github.com/rails/coffee-rails/tree/v#{s.version}",
+  }
+
   s.add_runtime_dependency 'coffee-script', '>= 2.2.0'
   s.add_runtime_dependency 'railties',      '>= 5.2.0'
 

--- a/coffee-rails.gemspec.erb
+++ b/coffee-rails.gemspec.erb
@@ -11,6 +11,13 @@ Gem::Specification.new do |s|
   s.summary     = %q{CoffeeScript adapter for the Rails asset pipeline.}
   s.description = %q{CoffeeScript adapter for the Rails asset pipeline.}
 
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/rails/coffee-rails/issues",
+    "changelog_uri"     => "https://github.com/rails/coffee-rails/blob/v#{s.version}/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/coffee-rails/#{s.version}",
+    "source_code_uri"   => "https://github.com/rails/coffee-rails/tree/v#{s.version}",
+  }
+
   s.add_runtime_dependency 'coffee-script', '>= 2.2.0'
   s.add_runtime_dependency 'railties',      '>= 5.2.0'
 


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/coffee-rails), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.