### PR TITLE
failing test case with .html.erb preferred instead of .coffee

### DIFF
--- a/test/template_handler_test.rb
+++ b/test/template_handler_test.rb
@@ -4,6 +4,15 @@ require 'coffee-rails'
 
 class SiteController < ActionController::Base
   self.view_paths = File.expand_path("../support", __FILE__)
+
+  # NOTE: Without this the index.html.erb template is selected
+  # when requesting index.js
+  # def index
+  #   respond_to do |format|
+  #     format.html
+  #     format.js { render formats: [:js] }
+  #   end
+  # end
 end
 
 DummyApp = ActionDispatch::Routing::RouteSet.new


### PR DESCRIPTION
This PR shows coffee-rails views not being picked for JS routes when a .html.erb template exists for the same action.

In the comments of the dummy controller are the currently necessary steps (I haven't found explicit documentation about needing to do this!) to make the `.coffee` file (or `.js.coffee`) being picked up and served when accessing `/site/index.js`.

NOTE: the current full test suite fails (even without these changes) since sprockets 4.0 will be installed and it requires a set up manifest.js for the asset pipeline...