### PR TITLE
CI: Remove unused sudo: false Travis directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 # To use rbx environment.
 dist: trusty
-sudo: false
 rvm:
   - 2.2
   - 2.3


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).