### PR TITLE
CI: Organize matrix to run something

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,33 @@
 language: ruby
 cache: bundler
 dist: trusty
-rvm:
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
-  - 2.6
-  - 2.7
-  - ruby-head
-  - jruby-9.2.6.0
 matrix:
   include:
     - gemfile: Gemfile
       rvm: 2.7
     - gemfile: Gemfile
       rvm: ruby-head
+
     - gemfile: gemfiles/Gemfile-6-1-stable
       rvm: 2.7
     - gemfile: gemfiles/Gemfile-6-1-stable
       rvm: 2.6
     - gemfile: gemfiles/Gemfile-6-1-stable
       rvm: 2.5
+
     - gemfile: gemfiles/Gemfile-6-0-stable
       rvm: 2.6
     - gemfile: gemfiles/Gemfile-6-0-stable
       rvm: 2.5
     - gemfile: gemfiles/Gemfile-6-0-stable
       rvm: jruby-9.2.6.0
+
     - gemfile: gemfiles/Gemfile-5-2-stable
       rvm: 2.2
     - gemfile: gemfiles/Gemfile-5-2-stable
       rvm: 2.3
     - gemfile: gemfiles/Gemfile-5-2-stable
       rvm: 2.4
-    - gemfile: gemfiles/Gemfile-5-2-stable
-      rvm: ruby-head
   allow_failures:
     - rvm: ruby-head
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,7 @@ rvm:
   - 2.6
   - ruby-head
   - jruby-9.2.6.0
-  - rbx-3
-gemfile:
-  - Gemfile
-  - gemfiles/Gemfile-5-2-stable
 matrix:
-  exclude:
-    - gemfile: Gemfile
   include:
     - gemfile: Gemfile
       rvm: 2.5
@@ -25,7 +19,7 @@ matrix:
     - gemfile: Gemfile
       rvm: ruby-head
     - gemfile: Gemfile
-      rvm: rbx-3
+      rvm: jruby-9.2.6.0
     - gemfile: gemfiles/Gemfile-5-2-stable
       rvm: 2.2
     - gemfile: gemfiles/Gemfile-5-2-stable
@@ -33,16 +27,9 @@ matrix:
     - gemfile: gemfiles/Gemfile-5-2-stable
       rvm: 2.4
     - gemfile: gemfiles/Gemfile-5-2-stable
-      rvm: 2.5
-    - gemfile: gemfiles/Gemfile-5-2-stable
-      rvm: 2.6
-    - gemfile: gemfiles/Gemfile-5-2-stable
       rvm: ruby-head
-    - gemfile: gemfiles/Gemfile-5-2-stable
-      rvm: rbx-3
   allow_failures:
     - rvm: ruby-head
-    - rvm: rbx-3
   fast_finish: true
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-# To use rbx environment.
 dist: trusty
 rvm:
   - 2.2
@@ -8,17 +7,26 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
   - jruby-9.2.6.0
 matrix:
   include:
     - gemfile: Gemfile
-      rvm: 2.5
-    - gemfile: Gemfile
-      rvm: 2.6
+      rvm: 2.7
     - gemfile: Gemfile
       rvm: ruby-head
-    - gemfile: Gemfile
+    - gemfile: gemfiles/Gemfile-6-1-stable
+      rvm: 2.7
+    - gemfile: gemfiles/Gemfile-6-1-stable
+      rvm: 2.6
+    - gemfile: gemfiles/Gemfile-6-1-stable
+      rvm: 2.5
+    - gemfile: gemfiles/Gemfile-6-0-stable
+      rvm: 2.6
+    - gemfile: gemfiles/Gemfile-6-0-stable
+      rvm: 2.5
+    - gemfile: gemfiles/Gemfile-6-0-stable
       rvm: jruby-9.2.6.0
     - gemfile: gemfiles/Gemfile-5-2-stable
       rvm: 2.2

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in coffee-rails.gemspec
 gemspec
 
-gem 'rails', git: 'https://github.com/rails/rails'
+gem 'rails', git: 'https://github.com/rails/rails', ref: 'main'

--- a/gemfiles/Gemfile-6-0-stable
+++ b/gemfiles/Gemfile-6-0-stable
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'rails', git: 'https://github.com/rails/rails', ref: '6-0-stable'
+

--- a/gemfiles/Gemfile-6-1-stable
+++ b/gemfiles/Gemfile-6-1-stable
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'rails', git: 'https://github.com/rails/rails', ref: '6-1-stable'
+


### PR DESCRIPTION
This PR configures the build matrix to include newer versions of Rails.

- use an explcitly defined build matrix
- run Ruby 2.2-2.4 with Sprockets 3 on Rails 5.2, still works
- Remove `rbx-3` - can not install


## TODO

- [ ] Sprockets 4 support
- [ ] OR: Fail on Sprockets 4 support needed for the newer versions, move those to "allow failures"?

## Other

Found a tiny issue, and extract its fix to https://github.com/rails/coffee-rails/pull/126.