### PR TITLE
Gemfile: refer to default branch "main" in Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in coffee-rails.gemspec
 gemspec
 
-gem 'rails', git: 'https://github.com/rails/rails'
+gem 'rails', git: 'https://github.com/rails/rails', branch: 'main'


### PR DESCRIPTION
This PR makes the Gemfile point to the right branch - for Bundler 1.x.

This will repair the test suite for older Ruby versions.

## Details

Newer Ruby versions will have issues, in that they are asking for a newer Sprockets, which is not configured with a `manifest.js`.

The test failures for the newer Ruby versions include cases like:

```
AssetsTest#test_coffee-script.js_is_included_in_Sprockets_environment:

Sprockets::Railtie::ManifestNeededError: Expected to find a manifest file in `app/assets/config/manifest.js`
But did not, please create this file and use it to link any assets that need to be rendered by your app:

Example:

  //= link_tree ../images
  //= link_directory ../javascripts .js
  //= link_directory ../stylesheets .css

and restart your server
```