### PR TITLE
Fix typo, Envinronment -> Environment

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-# Configure Rails Envinronment
+# Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
 require 'bundler/setup'


### PR DESCRIPTION
Found via `typos --format brief`